### PR TITLE
bugfix: clear local domeosAddr when modifying

### DIFF
--- a/src/main/java/org/domeos/framework/api/service/deployment/DeploymentService.java
+++ b/src/main/java/org/domeos/framework/api/service/deployment/DeploymentService.java
@@ -202,4 +202,11 @@ public interface DeploymentService {
      * @return
      */
     void updateJobResult(UpdateJobResult updateJobResult);
+	
+    /**
+     * clear local cache of DomeosAddr
+     * @return
+     */
+    void clearDomeosAddrCache();
+	
 }

--- a/src/main/java/org/domeos/framework/api/service/deployment/impl/DeploymentServiceImpl.java
+++ b/src/main/java/org/domeos/framework/api/service/deployment/impl/DeploymentServiceImpl.java
@@ -111,6 +111,11 @@ public class DeploymentServiceImpl implements DeploymentService {
     private String domeosAddr = null;
 
     private static Logger logger = LoggerFactory.getLogger(DeploymentServiceImpl.class);
+	
+    @Override
+    public void clearDomeosAddrCache() {
+        this.domeosAddr = null;
+    }
 
     private void checkDeployPermit(int deployId, OperationType operationType) {
         int userId = CurrentThreadInfo.getUserId();

--- a/src/main/java/org/domeos/framework/api/service/global/impl/ServerServiceImpl.java
+++ b/src/main/java/org/domeos/framework/api/service/global/impl/ServerServiceImpl.java
@@ -8,6 +8,7 @@ import org.domeos.framework.api.controller.exception.ApiException;
 import org.domeos.framework.api.controller.exception.PermitException;
 import org.domeos.framework.api.model.global.Server;
 import org.domeos.framework.api.service.global.ServerService;
+import org.domeos.framework.api.service.deployment.DeploymentService;
 import org.domeos.framework.engine.AuthUtil;
 import org.domeos.global.CurrentThreadInfo;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,6 +23,9 @@ public class ServerServiceImpl implements ServerService {
 
     @Autowired
     GlobalBiz globalBiz;
+	
+    @Autowired
+    DeploymentService deploymentService;
 
     private void checkAdmin() {
         if (!AuthUtil.isAdmin(CurrentThreadInfo.getUserId())) {
@@ -51,6 +55,7 @@ public class ServerServiceImpl implements ServerService {
         }
 
         globalBiz.deleteServer();
+        deploymentService.clearDomeosAddrCache();
         globalBiz.setServer(server);
         return ResultStat.OK.wrap(server);
     }


### PR DESCRIPTION
修改的问题：
当控制台修改domeosAddr时，
新部署的容器中仍然使用老的domeosAddr 